### PR TITLE
Integrate multiple changes from squid314 and shuhei, add support for MAIL_TO override address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'mail'
+gem 'gitlab'
+gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    gitlab (2.2.0)
+      httparty
+    httparty (0.11.0)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.23)
+    multi_json (1.7.7)
+    multi_xml (0.5.4)
+    polyglot (0.3.3)
+    rack (1.5.2)
+    rack-protection (1.5.0)
+      rack
+    sinatra (1.4.3)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+    treetop (1.4.14)
+      polyglot
+      polyglot (>= 0.3.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  gitlab
+  mail
+  sinatra

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Web hook script for notifying team members by email on push event
 Requirements
 ------------
 
-~~~~
-sudo gem install mail gitlab
-~~~~
+```
+bundle install
+```

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,5 +1,6 @@
 :mail:
-  :from: s-kagawa@m3.com
+  :from: nobody@example.com
+  :to: optional-mailing-list-to@example.com
   :delivery:
     :method: :smtp
     :options:
@@ -11,6 +12,6 @@
       :user_name: FIXME
       :password: FIXME
 :gitlab:
-  :url: https://rendezvous.m3.com/
-  :token: ZBBy4P4vzdC5ewL4WEQK
+  :url: https://gitlab.example.com/
+  :token: ZZZZZZZZZZFIXMEZZZZZ
 

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,0 +1,16 @@
+:mail:
+  :from: s-kagawa@m3.com
+  :delivery:
+    :method: :smtp
+    :options:
+      :enable_starttls_auto: true
+      :address: smtp.gmail.com
+      :port: 587
+      :domain: gmail.com
+      :authentication: :plain
+      :user_name: FIXME
+      :password: FIXME
+:gitlab:
+  :url: https://rendezvous.m3.com/
+  :token: ZBBy4P4vzdC5ewL4WEQK
+

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -3,6 +3,7 @@ require "cgi"
 require "json"
 require "gitlab"
 require "mail"
+require "date"
 
 # config
 GITLAB_URL = 'http://FIXME/'
@@ -37,19 +38,26 @@ exit if project.nil?
 mail_body = 
 "#{push_info['user_name']} pushed new commits to #{project_name}.
 
-* Project page
- - #{project_url}
+  Branch: #{push_info['ref']}
+  home:   #{project_url}
 
-* Commit info
 " +
 push_info['commits'].map {|commit|
   author = commit['author']
-" - by #{author['name']} <#{author['email']}>
-   #{commit['message']}
+"  Commit: #{commit['id']}:
+      #{commit['url']}:
+  Author: #{author['name']} <#{author['email']}>
+  Date:   #{DateTime.parse(commit['timestamp']).strftime('%Y-%m-%d (%a, %-d %b %Y)')}
+  Log Message:
+  -----------
+  #{commit['message']}
+
 
 "
 }.join('') +
-"----
+"Compare: #{project_url}/compare/#{push_info['before']}...#{push_info['after']}
+
+----
 This email is delivered by GitLab Web Hook."
 
 # get team member & send mail

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -7,7 +7,7 @@ require "mail"
 # config
 GITLAB_URL = 'http://FIXME/'
 GITLAB_TOKEN = 'FIXME'
-MAIL_FROM = 'FIXME'
+MAIL_SENDER = 'FIXME'
 
 # cgi
 cgi = CGI.new
@@ -33,6 +33,7 @@ exit if project.nil?
 
 # mail contents
 mail_subject = "GitLab | #{project_name} | notify"
+mail_from = "#{push_info['author']} <#{Gitlab.user(push_info['user_id']).email}>"
 mail_body = 
 "#{push_info['user_name']} pushed new commits to #{project_name}.
 
@@ -63,7 +64,8 @@ Mail.deliver do
     :password => "FIXME",
   }
   to Gitlab.team_members(project.id).map {|user| user.email }
-  from MAIL_FROM
+  sender MAIL_SENDER
+  from mail_from
   subject mail_subject
   body mail_body
 end

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -1,47 +1,73 @@
 #!/usr/bin/env ruby
-require "cgi"
-require "json"
-require "gitlab"
-require "mail"
+##require "cgi"
 require "date"
+require 'json'
+require 'gitlab'
+require 'mail'
+require 'yaml'
+require 'sinatra'
+
+config_path = File.join(File.dirname(__FILE__), 'config.yml')
+config = YAML::load(File.read(config_path))
 
 # config
-GITLAB_URL = 'http://FIXME/'
-GITLAB_TOKEN = 'FIXME'
-MAIL_SENDER = 'FIXME'
-GOOGLE_USERNAME = 'FIXME'
-GOOGLE_PASSWORD = 'FIXME'
+GITLAB_URL = config[:gitlab][:url]
+GITLAB_TOKEN = config[:gitlab][:token]
+MAIL_FROM = config[:mail][:from]
 
-# cgi
-cgi = CGI.new
-print "Content-type: text/html\n\n"
-
-# get push info
-push_info = JSON.parse(cgi.params.keys[0])
-
-# gitlab setup
-Gitlab.endpoint = "#{GITLAB_URL}api/v3"
-Gitlab.private_token = GITLAB_TOKEN
-
-# get project name
-project_url  = push_info['repository']['homepage']
-project_name = project_url.sub(GITLAB_URL, '')
-
-# get project info
-project = Gitlab.projects.find do |x|
-  x.path_with_namespace == project_name
+deli = config[:mail][:delivery]
+Mail.defaults do
+  delivery_method deli[:method], deli[:options]
 end
 
-exit if project.nil?
+def send_mail(push_body)
+  # get push info
+  push_info = JSON.parse(push_body)
 
+  # gitlab setup
+  Gitlab.endpoint = "#{GITLAB_URL}api/v3"
+  Gitlab.private_token = GITLAB_TOKEN
+
+  # get project name
+  project_url  = push_info['repository']['homepage']
+  project_name = project_url.sub(GITLAB_URL, '')
+
+  # get project info
+  project = Gitlab.projects.find do |x|
+    x.path_with_namespace == project_name
+  end
+
+  exit if project.nil?
+
+  # mail contents
+  mail_subject = "GitLab | #{project_name} | notify"
+  mail_body = generate_mail_body(project_name, project_url, push_info)
+
+  # get team members
+  ignore_list = (params['ignore'] || '').split(',')
+  developers = Gitlab.team_members(project.id)
+    .reject { |user| ignore_list.include?(user.email) }
+    .map { |user| user.email }
+
+  # send mail
+  Mail.deliver do
+    to developers
+    from MAIL_FROM
+    subject mail_subject
+    body mail_body
+  end
+end
+
+def generate_mail_body(project_name, project_url, push_info)
 # mail contents
-mail_body = 
-"#{push_info['user_name']} pushed new commits to #{project_name}.
+mail_body = <<-MAIL_BODY 
+#{push_info['user_name']} pushed new commits to #{project_name}.
 
   Branch: #{push_info['ref']}
   home:   #{project_url}
 
-" +
+MAIL_BODY
+mail_body += 
 push_info['commits'].map {|commit|
   author = commit['author']
 "  Commit: #{commit['id']}:
@@ -60,20 +86,10 @@ push_info['commits'].map {|commit|
 ----
 This email is delivered by GitLab Web Hook."
 
-# get team member & send mail
-Mail.deliver do
-  delivery_method :smtp, {
-    :enable_starttls_auto => true,
-    :address => "smtp.gmail.com",
-    :port => 587,
-    :domain => "gmail.com",
-    :authentication => :plain,
-    :user_name => GOOGLE_USERNAME,
-    :password => GOOGLE_PASSWORD,
-  }
-  to Gitlab.team_members(project.id).map {|user| user.email }
-  sender MAIL_SENDER
-  from "#{push_info['author']} <#{Gitlab.user(push_info['user_id']).email}>"
-  subject "GitLab | #{project_name} | notify"
-  body mail_body
+  mail_body
+end
+
+post '/' do
+  push_body = request.body.read
+  send_mail(push_body)
 end

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -8,6 +8,8 @@ require "mail"
 GITLAB_URL = 'http://FIXME/'
 GITLAB_TOKEN = 'FIXME'
 MAIL_SENDER = 'FIXME'
+GOOGLE_USERNAME = 'FIXME'
+GOOGLE_PASSWORD = 'FIXME'
 
 # cgi
 cgi = CGI.new
@@ -32,8 +34,6 @@ end
 exit if project.nil?
 
 # mail contents
-mail_subject = "GitLab | #{project_name} | notify"
-mail_from = "#{push_info['author']} <#{Gitlab.user(push_info['user_id']).email}>"
 mail_body = 
 "#{push_info['user_name']} pushed new commits to #{project_name}.
 
@@ -60,12 +60,12 @@ Mail.deliver do
     :port => 587,
     :domain => "gmail.com",
     :authentication => :plain,
-    :user_name => "FIXME",
-    :password => "FIXME",
+    :user_name => GOOGLE_USERNAME,
+    :password => GOOGLE_PASSWORD,
   }
   to Gitlab.team_members(project.id).map {|user| user.email }
   sender MAIL_SENDER
-  from mail_from
-  subject mail_subject
+  from "#{push_info['author']} <#{Gitlab.user(push_info['user_id']).email}>"
+  subject "GitLab | #{project_name} | notify"
   body mail_body
 end

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -41,15 +41,15 @@ mail_body =
  - #{project_url}
 
 * Commit info
-"
-
-push_info['commits'].each do |commit|
+" +
+push_info['commits'].map {|commit|
   author = commit['author']
-  mail_body += " - by #{author['name']} <#{author['email']}>\n"
-  mail_body += "   #{commit['message']}\n\n"
-end
+" - by #{author['name']} <#{author['email']}>
+   #{commit['message']}
 
-mail_body += "----
+"
+}.join('') +
+"----
 This email is delivered by GitLab Web Hook."
 
 # get team member & send mail

--- a/gitlab-email-notify.rb
+++ b/gitlab-email-notify.rb
@@ -9,18 +9,6 @@ GITLAB_URL = 'http://FIXME/'
 GITLAB_TOKEN = 'FIXME'
 MAIL_FROM = 'FIXME'
 
-Mail.defaults do
-  delivery_method :smtp, {
-    :enable_starttls_auto => true,
-    :address => "smtp.gmail.com",
-    :port => 587,
-    :domain => "gmail.com",
-    :authentication => :plain,
-    :user_name => "FIXME",
-    :password => "FIXME",
-  }
-end
-
 # cgi
 cgi = CGI.new
 print "Content-type: text/html\n\n"
@@ -65,6 +53,15 @@ This email is delivered by GitLab Web Hook."
 
 # get team member & send mail
 Mail.deliver do
+  delivery_method :smtp, {
+    :enable_starttls_auto => true,
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => "gmail.com",
+    :authentication => :plain,
+    :user_name => "FIXME",
+    :password => "FIXME",
+  }
   to Gitlab.team_members(project.id).map {|user| user.email }
   from MAIL_FROM
   subject mail_subject


### PR DESCRIPTION
@squid314 and @shuhei made significant improvements to this that were very helpful to us, including externalizing the configuration into a yml file, and using bundler to install the Ruby dependencies.

I went a bit further by adding support for a MAIL_TO override address.

This has been working well in production for Modus Create since May 2014.

Please accept this pull request so that others may benefit.